### PR TITLE
feat: Add portable local execution backend for macOS/Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,10 @@ Thumbs.db
 # SLURM output files
 slurm_logs/
 slurm-*.out # Older SLURM naming pattern, just in case
+
+# Tex files
+*.aux
+*.bbl
+*.blg  
+
+master_thesis/

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ pip install -r requirements.txt
 python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
 ```
 
-### Option C: Apple Silicon / macOS (local execution)
+### Option B: Apple Silicon / macOS (local execution)
 
 ```bash
 git clone https://github.com/Przemyslaw11/BeyondBackpropagation.git
@@ -213,7 +213,7 @@ python -c "import torch; print(torch.__version__, torch.backends.mps.is_availabl
 
 MPS acceleration is used automatically when `general.backend: local` and `general.device: auto`. Falls back to CPU when MPS is unavailable.
 
-### Option B: conda (Linux / cluster)
+### Option C: conda (Linux / cluster)
 
 ```bash
 git clone https://github.com/Przemyslaw11/BeyondBackpropagation.git

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ All values are reported on the held-out test split and averaged over 3 runs in t
 |-- scripts/
 |   |-- run_experiment.py              # single train-and-test entry point
 |   |-- run_optuna_search.py           # Optuna HPO entry point
+|   |-- run_local_array.py             # local sequential batch runner (replaces Slurm array)
 |   |-- slurm_scripts/
 |   |   |-- run_single_experiment.slurm
 |   |   |-- run_array.slurm
@@ -184,7 +185,7 @@ Tested paper environment:
 | Weights & Biases | 0.19.8 |
 | pynvml | 12.0.0 |
 
-### Option A: virtualenv
+### Option A: virtualenv (Linux / cluster)
 
 ```bash
 git clone https://github.com/Przemyslaw11/BeyondBackpropagation.git
@@ -196,7 +197,23 @@ pip install -r requirements.txt
 python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
 ```
 
-### Option B: conda
+### Option C: Apple Silicon / macOS (local execution)
+
+```bash
+git clone https://github.com/Przemyslaw11/BeyondBackpropagation.git
+cd BeyondBackpropagation
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+# Install PyTorch with MPS support (macOS / arm64)
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+pip install -r requirements.txt
+python -c "import torch; print(torch.__version__, torch.backends.mps.is_available())"
+```
+
+MPS acceleration is used automatically when `general.backend: local` and `general.device: auto`. Falls back to CPU when MPS is unavailable.
+
+### Option B: conda (Linux / cluster)
 
 ```bash
 git clone https://github.com/Przemyslaw11/BeyondBackpropagation.git
@@ -288,6 +305,12 @@ The simplest reproducible path is to run a single MF experiment. The command tra
 python scripts/run_experiment.py --config configs/mf/mnist_mlp_2x1000.yaml
 ```
 
+To run locally on Apple Silicon (uses MPS / CPU fallback):
+
+```bash
+python scripts/run_experiment.py --config configs/mf/mnist_mlp_2x1000.yaml --backend local
+```
+
 Main CIFAR-10 MF result from the paper:
 
 ```bash
@@ -311,6 +334,19 @@ Run hyperparameter search:
 
 ```bash
 python scripts/run_optuna_search.py --config configs/tuning/mf_cifar10_mlp_3x2000_mf_tune.yaml --n-trials 50
+```
+
+Run hyperparameter search locally:
+
+```bash
+python scripts/run_optuna_search.py --config configs/tuning/mf_cifar10_mlp_3x2000_mf_tune.yaml --backend local --n-trials 20
+```
+
+Run a local batch (equivalent to the Slurm array workflow):
+
+```bash
+python scripts/run_local_array.py --config-dir configs/mf/
+python scripts/run_local_array.py --glob "configs/**/*.yaml"
 ```
 
 Run on SLURM:
@@ -339,6 +375,7 @@ Key fields:
 | Field | Meaning |
 |---|---|
 | `experiment_name` | Run name used for logs, W&B, results, and checkpoints. |
+| `general.backend` | Execution backend: `"slurm"` (default) or `"local"`. Override via `--backend` CLI flag. |
 | `algorithm.name` | One of `BP`, `FF`, `CaFo`, or `MF`. |
 | `data.name` | One of `MNIST`, `FashionMNIST`, `CIFAR10`, `CIFAR100`. |
 | `data.root` | Dataset directory. Defaults to `./data`. |

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,6 +1,21 @@
 general:
   seed: 42
   device: "auto"
+  backend: "slurm"
+
+backend:
+  slurm:
+    results_dir: "results"
+    log_file: null
+    data_loader:
+      num_workers: 4
+      pin_memory: true
+  local:
+    results_dir: "results/local"
+    log_file: null
+    data_loader:
+      num_workers: 0
+      pin_memory: false
 
 training:
   epochs: 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ scikit-learn       # Allow latest compatible
 tqdm               # Allow latest compatible
 
 codecarbon         # Add CodeCarbon library
+
+# Environment
+python-dotenv       # Load .env files automatically

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -8,6 +8,7 @@ import pprint
 import sys
 
 import yaml
+from dotenv import load_dotenv
 
 from src.utils.backend_policy import get_execution_backend
 from src.training.engine import run_training
@@ -75,6 +76,7 @@ def main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
+    load_dotenv()
     parser = argparse.ArgumentParser(
         description="Run a deep learning experiment based on a configuration file."
     )

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -9,6 +9,7 @@ import sys
 
 import yaml
 
+from src.utils.backend_policy import get_execution_backend
 from src.training.engine import run_training
 from src.utils.config_parser import load_config
 from src.utils.helpers import create_directory_if_not_exists
@@ -24,21 +25,22 @@ def main(args: argparse.Namespace) -> None:
     print(f"Loading and merging configuration from: {args.config}")
     try:
         config = load_config(args.config)
+        if args.backend:
+            config.setdefault("general", {})["backend"] = args.backend
+        backend = get_execution_backend(config)
         print("Configuration loaded and merged successfully:")
         pprint.pprint(config)
 
-        log_config = config.get("logging", {})
-        results_dir = config.get("results", {}).get("dir", "results")
         exp_name = config.get(
             "experiment_name", os.path.splitext(os.path.basename(args.config))[0]
         )
-        default_log_file = os.path.join(results_dir, exp_name, f"{exp_name}_run.log")
-        log_file_path = log_config.get("log_file", default_log_file)
+        log_file_path = backend.resolve_log_file(config, exp_name)
 
         log_dir = os.path.dirname(log_file_path)
         create_directory_if_not_exists(log_dir)
 
-        setup_logging(log_level=log_config.get("level", "INFO"), log_file=log_file_path)
+        log_level = config.get("logging", {}).get("level", "INFO")
+        setup_logging(log_level=log_level, log_file=log_file_path)
 
     except (OSError, FileNotFoundError, yaml.YAMLError) as e:
         logger.error(f"Error loading or merging configuration: {e}", exc_info=True)
@@ -81,6 +83,13 @@ if __name__ == "__main__":
         type=str,
         required=True,
         help="Path to the YAML configuration file for the experiment.",
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["slurm", "local"],
+        default=None,
+        help="Execution backend to use. Defaults to the config value or Slurm.",
     )
 
     cli_args = parser.parse_args()

--- a/scripts/run_local_array.py
+++ b/scripts/run_local_array.py
@@ -17,6 +17,8 @@ import os
 import sys
 import time
 
+from dotenv import load_dotenv
+
 from src.utils.backend_policy import get_execution_backend
 from src.utils.config_parser import load_config
 from src.utils.helpers import create_directory_if_not_exists
@@ -77,6 +79,7 @@ def run_experiment(config_path: str, backend_name: str) -> dict:
 
 
 def main() -> None:
+    load_dotenv()
     parser = argparse.ArgumentParser(description="Run experiment configs sequentially on local backend.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(

--- a/scripts/run_local_array.py
+++ b/scripts/run_local_array.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Local batch runner: run multiple experiment configs sequentially.
+
+Replicates the Slurm array workflow (scripts/slurm_scripts/run_array.slurm)
+for local macOS execution using the local execution backend (MPS/CPU).
+
+Usage:
+  python scripts/run_local_array.py --config-dir configs/bp_baselines/
+  python scripts/run_local_array.py --configs configs/ff/mnist.yaml configs/mf/mnist.yaml
+  python scripts/run_local_array.py --glob "configs/**/*.yaml"
+"""
+
+import argparse
+import glob as glob_module
+import logging
+import os
+import sys
+import time
+
+from src.utils.backend_policy import get_execution_backend
+from src.utils.config_parser import load_config
+from src.utils.helpers import create_directory_if_not_exists
+from src.utils.logging_utils import setup_logging
+
+
+def collect_configs(args: argparse.Namespace) -> list[str]:
+    paths: list[str] = []
+    if args.config_dir:
+        for root, _dirs, files in os.walk(args.config_dir):
+            for f in files:
+                if f.endswith((".yaml", ".yml")):
+                    paths.append(os.path.join(root, f))
+        paths.sort()
+    if args.configs:
+        paths.extend(args.configs)
+    if args.glob:
+        paths.extend(sorted(glob_module.glob(args.glob, recursive=True)))
+    seen = set()
+    unique = []
+    for p in paths:
+        absp = os.path.abspath(p)
+        if absp not in seen:
+            seen.add(absp)
+            unique.append(p)
+    return unique
+
+
+def run_experiment(config_path: str, backend_name: str) -> dict:
+    import pprint
+
+    from src.training.engine import run_training
+
+    config = load_config(config_path)
+    config.setdefault("general", {})["backend"] = backend_name
+    backend = get_execution_backend(config)
+
+    exp_name = config.get("experiment_name", os.path.splitext(os.path.basename(config_path))[0])
+    log_file = backend.resolve_log_file(config, exp_name)
+    log_dir = os.path.dirname(log_file)
+    create_directory_if_not_exists(log_dir)
+
+    log_level = config.get("logging", {}).get("level", "INFO")
+    setup_logging(log_level=log_level, log_file=log_file)
+
+    log = logging.getLogger(__name__)
+    log.info("=" * 60)
+    log.info("Config: %s", config_path)
+    log.info("Backend: %s, Device: %s", backend.name, backend.resolve_device("auto"))
+    log.info("=" * 60)
+
+    results = run_training(config, wandb_run=None)
+    results.pop("codecarbon_emissions_kgCO2e", None)
+    log.info("Results for %s:", config_path)
+    for line in pprint.pformat(results).split("\n"):
+        log.info(line)
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run experiment configs sequentially on local backend.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--config-dir",
+        type=str,
+        default=None,
+        help="Directory containing YAML config files (non-recursive walk).",
+    )
+    group.add_argument(
+        "--configs",
+        type=str,
+        nargs="+",
+        default=None,
+        help="One or more YAML config file paths.",
+    )
+    group.add_argument(
+        "--glob",
+        type=str,
+        default=None,
+        help="Glob pattern for config files (e.g. 'configs/**/*.yaml').",
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["local", "slurm"],
+        default="local",
+        help="Execution backend (default: local).",
+    )
+    parser.add_argument(
+        "--max-configs",
+        type=int,
+        default=None,
+        help="Maximum number of configs to run (for testing).",
+    )
+    args = parser.parse_args()
+
+    config_paths = collect_configs(args)
+    if not config_paths:
+        print("No config files found.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.max_configs:
+        config_paths = config_paths[: args.max_configs]
+
+    print(f"Found {len(config_paths)} config(s). Backend: {args.backend}")
+    print("-" * 60)
+
+    summary: list[dict] = []
+    global_start = time.time()
+    for idx, config_path in enumerate(config_paths, start=1):
+        print(f"\n[{idx}/{len(config_paths)}] Running: {config_path}")
+        try:
+            results = run_experiment(config_path, args.backend)
+            summary.append({"config": config_path, "status": "ok", "results": results})
+        except Exception as e:
+            logging.getLogger(__name__).critical("Experiment failed: %s", e, exc_info=True)
+            summary.append({"config": config_path, "status": "failed", "error": str(e)})
+
+    total_duration = time.time() - global_start
+    print("\n" + "=" * 60)
+    print("BATCH SUMMARY")
+    print("=" * 60)
+    ok_count = sum(1 for s in summary if s["status"] == "ok")
+    fail_count = sum(1 for s in summary if s["status"] == "failed")
+    print(f"Total: {len(summary)}  |  Succeeded: {ok_count}  |  Failed: {fail_count}")
+    print(f"Total duration: {total_duration:.1f}s")
+    if fail_count > 0:
+        print("\nFailed configs:")
+        for s in summary:
+            if s["status"] == "failed":
+                print(f"  - {s['config']}: {s['error']}")
+    sys.exit(1 if fail_count > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_optuna_search.py
+++ b/scripts/run_optuna_search.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import optuna
 import yaml
+from dotenv import load_dotenv
 
 from src.utils.backend_policy import get_execution_backend
 from src.tuning.optuna_objective import objective as objective_bp
@@ -298,6 +299,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    load_dotenv()
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
     )

--- a/scripts/run_optuna_search.py
+++ b/scripts/run_optuna_search.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import optuna
 import yaml
 
+from src.utils.backend_policy import get_execution_backend
 from src.tuning.optuna_objective import objective as objective_bp
 from src.tuning.optuna_objective_cafo import objective_cafo
 from src.tuning.optuna_objective_ff import objective_ff
@@ -47,6 +48,13 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Number of trials to run (overrides config).",
     )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["slurm", "local"],
+        default=None,
+        help="Execution backend to use. Defaults to the config value or Slurm.",
+    )
     return parser.parse_args()
 
 
@@ -56,6 +64,9 @@ def main() -> None:
 
     try:
         config = load_config(args.config)
+        if args.backend:
+            config.setdefault("general", {})["backend"] = args.backend
+        backend = get_execution_backend(config)
         logger.info(f"Loaded configuration from: {args.config}")
         logger.info("Initial Config for Optuna:")
         config_str = pprint.pformat(config)
@@ -85,19 +96,20 @@ def main() -> None:
         )
         return
 
-    create_directory_if_not_exists(args.output_dir)
+    output_dir = args.output_dir or os.path.join(backend.resolve_results_dir(config), "optuna")
+    create_directory_if_not_exists(output_dir)
     if args.study_name is None:
         config_filename = os.path.splitext(os.path.basename(args.config))[0]
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         study_name = f"{config_filename}_optuna_{algorithm_name}_{timestamp}"
     else:
         study_name = args.study_name
-    log_file = os.path.join(args.output_dir, f"{study_name}.log")
+    log_file = os.path.join(output_dir, f"{study_name}.log")
 
     log_level_str = config.get("logging", {}).get("level", "INFO")
     setup_logging(log_level=log_level_str, log_file=log_file)
     logger.info(f"Optuna study name: {study_name}")
-    logger.info(f"Saving logs and study database to: {args.output_dir}")
+    logger.info(f"Saving logs and study database to: {output_dir}")
 
     tuning_config = config.get("tuning", {})
     if not tuning_config or not tuning_config.get("enabled", False):
@@ -108,7 +120,7 @@ def main() -> None:
         if args.n_trials is not None
         else tuning_config.get("n_trials", 20)
     )
-    storage_path = f"sqlite:///{os.path.join(args.output_dir, f'{study_name}.db')}"
+    storage_path = f"sqlite:///{os.path.join(output_dir, f'{study_name}.db')}"
     sampler_type = tuning_config.get("sampler", "TPE").upper()
     pruner_type = tuning_config.get("pruner", "Median").upper()
     if algorithm_name in ["MF", "CAFO", "FF"] and pruner_type != "NONE":
@@ -255,9 +267,7 @@ def main() -> None:
             + "\n"
         )
 
-        best_params_file = os.path.join(
-            args.output_dir, f"{study_name}_best_params.yaml"
-        )
+        best_params_file = os.path.join(output_dir, f"{study_name}_best_params.yaml")
         study_results_summary = {
             "study_name": study_name,
             "algorithm": algorithm_name,

--- a/src/data_utils/datasets.py
+++ b/src/data_utils/datasets.py
@@ -1,11 +1,13 @@
 """Functions and classes for creating PyTorch DataLoaders."""
 
 import logging
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
 import torchvision
 from torch.utils.data import DataLoader, Dataset, Subset, random_split
+
+from src.utils.backend_policy import get_execution_backend
 
 from .preprocessing import get_transforms
 
@@ -44,8 +46,10 @@ def get_dataloaders(
     data_root: str = "./data",
     val_split: float = 0.1,
     seed: Optional[int] = None,
-    num_workers: int = 4,
-    pin_memory: bool = True,
+    config: Optional[Dict[str, Any]] = None,
+    backend: str = "slurm",
+    num_workers: Optional[int] = None,
+    pin_memory: Optional[bool] = None,
     download: bool = True,
 ) -> Tuple[DataLoader, Optional[DataLoader], DataLoader]:
     """Creates training, validation, and test DataLoaders for a specified dataset.
@@ -60,6 +64,8 @@ def get_dataloaders(
         data_root: The root directory for the dataset.
         val_split: The fraction of the training data to use for validation.
         seed: Random seed for reproducibility of the split.
+        config: Full merged configuration, used for backend-aware defaults.
+        backend: Execution backend name, used when backend-aware defaults are needed.
         num_workers: Number of subprocesses to use for data loading.
         pin_memory: If True, copies Tensors into CUDA pinned memory before returning.
         download: If True, downloads the dataset if it is not found locally.
@@ -76,6 +82,15 @@ def get_dataloaders(
     except ValueError as e:
         logger.error(f"Failed to get transforms: {e}")
         raise
+
+    backend_policy = get_execution_backend({"general": {"backend": backend}})
+    loader_defaults = backend_policy.resolve_dataloader_defaults(config)
+    resolved_num_workers = (
+        num_workers if num_workers is not None else loader_defaults["num_workers"]
+    )
+    resolved_pin_memory = (
+        pin_memory if pin_memory is not None else loader_defaults["pin_memory"]
+    )
 
     dataset_class = None
     if dataset_name == "fashionmnist":
@@ -193,13 +208,13 @@ def get_dataloaders(
                 transform=train_transform,
             )
             val_dataset = None
-    persistent_workers = num_workers > 0
+    persistent_workers = resolved_num_workers > 0
     train_loader = DataLoader(
         dataset=train_dataset,
         batch_size=batch_size,
         shuffle=True,
-        num_workers=num_workers,
-        pin_memory=pin_memory,
+        num_workers=resolved_num_workers,
+        pin_memory=resolved_pin_memory,
         drop_last=True,
         persistent_workers=persistent_workers,
     )
@@ -209,8 +224,8 @@ def get_dataloaders(
             dataset=val_dataset,
             batch_size=batch_size * 2,
             shuffle=False,
-            num_workers=num_workers,
-            pin_memory=pin_memory,
+            num_workers=resolved_num_workers,
+            pin_memory=resolved_pin_memory,
             drop_last=False,
             persistent_workers=persistent_workers,
         )
@@ -223,8 +238,8 @@ def get_dataloaders(
         dataset=test_dataset,
         batch_size=batch_size * 2,
         shuffle=False,
-        num_workers=num_workers,
-        pin_memory=pin_memory,
+        num_workers=resolved_num_workers,
+        pin_memory=resolved_pin_memory,
         drop_last=False,
         persistent_workers=persistent_workers,
     )

--- a/src/training/engine.py
+++ b/src/training/engine.py
@@ -18,6 +18,7 @@ from src.algorithms import (
 )
 from src.architectures import FF_MLP, MF_MLP, CaFo_CNN
 from src.data_utils.datasets import get_dataloaders
+from src.utils.backend_policy import get_execution_backend
 from src.utils.codecarbon_utils import setup_codecarbon_tracker
 from src.utils.helpers import format_time, set_seed
 from src.utils.logging_utils import log_metrics, logger, setup_wandb
@@ -168,6 +169,10 @@ def _setup_environment_and_wandb(
 ) -> Tuple[int, torch.device, Optional["wandb.sdk.wandb_run.Run"]]:
     """Initializes seed, device, and Weights & Biases."""
     general_config = config.get("general", {})
+    backend = get_execution_backend(config)
+    for key, value in backend.prepare_environment().items():
+        os.environ.setdefault(key, value)
+
     seed = general_config.get("seed", 42)
     env_seed_str = os.environ.get("EXPERIMENT_SEED")
     if env_seed_str:
@@ -182,19 +187,11 @@ def _setup_environment_and_wandb(
     set_seed(seed)
     logger.info(f"Using random seed: {seed}")
 
-    device_pref = general_config.get("device", "auto").lower()
-    device = torch.device(
-        "cuda"
-        if device_pref == "cuda" and torch.cuda.is_available()
-        else (
-            "cpu"
-            if device_pref == "cpu"
-            else "cuda"
-            if torch.cuda.is_available()
-            else "cpu"
-        )
+    device_pref = general_config.get("device", "auto")
+    device = backend.resolve_device(device_pref)
+    logger.info(
+        f"Using backend: {backend.name}, device: {device} (Preference: '{device_pref}')"
     )
-    logger.info(f"Using device: {device} (Preference: '{device_pref}')")
 
     if wandb_run is None:
         wandb_run = setup_wandb(config, job_type="training")
@@ -401,6 +398,7 @@ def run_training(
 
     try:
         seed, device, wandb_run = _setup_environment_and_wandb(config, wandb_run)
+        backend = get_execution_backend(config)
 
         (
             nvml_active,
@@ -419,10 +417,8 @@ def run_training(
             data_root=data_config.get("root", "./data"),
             val_split=data_config.get("val_split", 0.1),
             seed=seed,
-            num_workers=loader_config.get("num_workers", 4),
-            pin_memory=(
-                loader_config.get("pin_memory", True) and device.type == "cuda"
-            ),
+            config=config,
+            backend=backend.name,
         )
         logger.info("Dataloaders created.")
 

--- a/src/tuning/optuna_objective.py
+++ b/src/tuning/optuna_objective.py
@@ -20,6 +20,7 @@ from src.data_utils.datasets import get_dataloaders
 from src.training.engine import (
     get_model_and_adapter,
 )
+from src.utils.backend_policy import get_execution_backend
 from src.utils.helpers import format_time, set_seed
 
 logger = logging.getLogger(__name__)
@@ -52,12 +53,9 @@ def _get_trial_config(
 
 def _get_device(cfg: Dict[str, Any]) -> torch.device:
     """Sets up the device for a trial."""
-    device_name = cfg.get("general", {}).get("device", "auto").lower()
-    if device_name == "cuda" and torch.cuda.is_available():
-        return torch.device("cuda")
-    if device_name == "cpu":
-        return torch.device("cpu")
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    backend = get_execution_backend(cfg)
+    device_name = cfg.get("general", {}).get("device", "auto")
+    return backend.resolve_device(device_name)
 
 
 def _create_bp_optimizer(
@@ -195,8 +193,8 @@ def objective(trial: optuna.Trial, base_config: Dict[str, Any]) -> float:
             data_root=data_config.get("root", "./data"),
             val_split=data_config.get("val_split", 0.1),
             seed=trial_seed,
-            num_workers=0,
-            pin_memory=False,
+            config=cfg,
+            backend=cfg.get("general", {}).get("backend", "slurm"),
             download=data_config.get("download", True),
         )
         if not val_loader:

--- a/src/tuning/optuna_objective_cafo.py
+++ b/src/tuning/optuna_objective_cafo.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from src.algorithms.cafo import evaluate_cafo_model, train_cafo_model
 from src.data_utils.datasets import get_dataloaders
 from src.training.engine import get_model_and_adapter
+from src.utils.backend_policy import get_execution_backend
 from src.utils.helpers import format_time, set_seed
 
 logger = logging.getLogger(__name__)
@@ -61,13 +62,8 @@ def _setup_cafo_trial(
     # Setup environment
     trial_seed = cfg.get("general", {}).get("seed", 42) + trial.number
     set_seed(trial_seed)
-    device_name = cfg.get("general", {}).get("device", "auto").lower()
-    if device_name == "cuda" and torch.cuda.is_available():
-        device = torch.device("cuda")
-    elif device_name == "cpu":
-        device = torch.device("cpu")
-    else:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    backend = get_execution_backend(cfg)
+    device = backend.resolve_device(cfg.get("general", {}).get("device", "auto"))
 
     return cfg, device, trial_seed
 
@@ -100,8 +96,8 @@ def objective_cafo(trial: optuna.Trial, base_config: Dict[str, Any]) -> float:
             data_root=data_config.get("root", "./data"),
             val_split=data_config.get("val_split", 0.1),
             seed=trial_seed,
-            num_workers=0,
-            pin_memory=False,
+            config=cfg,
+            backend=cfg.get("general", {}).get("backend", "slurm"),
             download=data_config.get("download", True),
         )
         if not val_loader:

--- a/src/tuning/optuna_objective_ff.py
+++ b/src/tuning/optuna_objective_ff.py
@@ -12,6 +12,7 @@ import torch
 from src.algorithms.ff import evaluate_ff_model, train_ff_model
 from src.architectures.ff_mlp import FF_MLP
 from src.data_utils.datasets import get_dataloaders
+from src.utils.backend_policy import get_execution_backend
 from src.utils.helpers import format_time, set_seed
 
 logger = logging.getLogger(__name__)
@@ -47,13 +48,8 @@ def _setup_ff_trial(
     # Setup environment
     trial_seed = cfg.get("general", {}).get("seed", 42) + trial.number
     set_seed(trial_seed)
-    device_name = cfg.get("general", {}).get("device", "auto").lower()
-    if device_name == "cuda" and torch.cuda.is_available():
-        device = torch.device("cuda")
-    elif device_name == "cpu":
-        device = torch.device("cpu")
-    else:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    backend = get_execution_backend(cfg)
+    device = backend.resolve_device(cfg.get("general", {}).get("device", "auto"))
 
     return cfg, device, trial_seed
 
@@ -85,8 +81,8 @@ def objective_ff(trial: optuna.Trial, base_config: Dict[str, Any]) -> float:
             data_root=data_config.get("root", "./data"),
             val_split=data_config.get("val_split", 0.1),
             seed=trial_seed,
-            num_workers=0,
-            pin_memory=False,
+            config=cfg,
+            backend=cfg.get("general", {}).get("backend", "slurm"),
             download=data_config.get("download", True),
         )
         if not val_loader:

--- a/src/tuning/optuna_objective_mf.py
+++ b/src/tuning/optuna_objective_mf.py
@@ -12,6 +12,7 @@ import torch
 from src.algorithms.mf import evaluate_mf_model, train_mf_model
 from src.data_utils.datasets import get_dataloaders
 from src.training.engine import get_model_and_adapter
+from src.utils.backend_policy import get_execution_backend
 from src.utils.helpers import format_time, set_seed
 
 logger = logging.getLogger(__name__)
@@ -40,11 +41,8 @@ def _setup_mf_trial(
     # Setup environment
     trial_seed = cfg.get("general", {}).get("seed", 42) + trial.number
     set_seed(trial_seed)
-    device_name = cfg.get("general", {}).get("device", "auto").lower()
-    if device_name == "cuda" and torch.cuda.is_available():
-        device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
+    backend = get_execution_backend(cfg)
+    device = backend.resolve_device(cfg.get("general", {}).get("device", "auto"))
 
     return cfg, device, trial_seed
 
@@ -77,8 +75,8 @@ def objective_mf(trial: optuna.Trial, base_config: Dict[str, Any]) -> float:
             data_root=data_config.get("root", "./data"),
             val_split=data_config.get("val_split", 0.1),
             seed=trial_seed,
-            num_workers=0,
-            pin_memory=False,
+            config=cfg,
+            backend=cfg.get("general", {}).get("backend", "slurm"),
             download=data_config.get("download", True),
         )
 

--- a/src/utils/backend_policy.py
+++ b/src/utils/backend_policy.py
@@ -1,0 +1,159 @@
+"""Backend policy helpers for local and Slurm-style execution."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - allows import-time validation without torch.
+    torch = None  # type: ignore[assignment]
+
+
+def _mps_is_available() -> bool:
+    """Return True when PyTorch can execute on Apple Silicon MPS."""
+    if torch is None:
+        return False
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is None:
+        return False
+    is_available = getattr(mps_backend, "is_available", None)
+    is_built = getattr(mps_backend, "is_built", None)
+    return bool(
+        callable(is_available)
+        and callable(is_built)
+        and is_available()
+        and is_built()
+    )
+
+
+def _normalize_backend_name(name: str | None) -> str:
+    backend_name = (name or "slurm").strip().lower()
+    return backend_name if backend_name in {"local", "slurm"} else "slurm"
+
+
+@dataclass(frozen=True)
+class ExecutionBackend:
+    """Base policy for runtime decisions that differ by execution environment."""
+
+    name: str
+
+    def resolve_device(self, device_preference: str = "auto") -> torch.device:
+        """Resolve the PyTorch device for the backend."""
+        if torch is None:
+            raise RuntimeError("PyTorch is required to resolve execution devices.")
+        preference = (device_preference or "auto").strip().lower()
+
+        if preference == "cpu":
+            return torch.device("cpu")
+        if preference == "cuda":
+            return (
+                torch.device("cuda")
+                if torch.cuda.is_available()
+                else self._fallback_device()
+            )
+        if preference == "mps":
+            return torch.device("mps") if _mps_is_available() else self._fallback_device()
+
+        return self._fallback_device()
+
+    def _fallback_device(self) -> torch.device:
+        if torch is None:
+            raise RuntimeError("PyTorch is required to resolve execution devices.")
+        if self.name == "local":
+            if _mps_is_available():
+                return torch.device("mps")
+            return torch.device("cpu")
+
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
+    def resolve_dataloader_defaults(self, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Return backend-friendly DataLoader defaults."""
+        if torch is None:
+            return {"num_workers": 0, "pin_memory": False}
+
+        defaults = (
+            {"num_workers": 0, "pin_memory": False}
+            if self.name == "local"
+            else (
+                {"num_workers": 4, "pin_memory": True}
+                if torch.cuda.is_available()
+                else {"num_workers": 0, "pin_memory": False}
+            )
+        )
+
+        if not isinstance(config, dict):
+            return defaults
+
+        backend_config = config.get("backend", {}).get(self.name, {})
+        loader_config = backend_config.get("data_loader", {})
+        if loader_config:
+            for key in ("num_workers", "pin_memory"):
+                if key in loader_config and loader_config[key] is not None:
+                    defaults[key] = loader_config[key]
+            return defaults
+
+        legacy_loader_config = config.get("data_loader", {})
+        for key in ("num_workers", "pin_memory"):
+            if key in legacy_loader_config and legacy_loader_config[key] is not None:
+                defaults[key] = legacy_loader_config[key]
+        return defaults
+
+    def resolve_results_dir(self, config: Dict[str, Any]) -> str:
+        """Resolve the default results directory for the backend."""
+        backend_config = config.get("backend", {}).get(self.name, {})
+        explicit_dir = backend_config.get("results_dir") or config.get("results", {}).get(
+            "dir"
+        )
+        if explicit_dir:
+            return explicit_dir
+        return "results/local" if self.name == "local" else "results"
+
+    def resolve_log_file(self, config: Dict[str, Any], experiment_name: str) -> str:
+        """Resolve the default run log file path."""
+        backend_config = config.get("backend", {}).get(self.name, {})
+        log_config = config.get("logging", {})
+        explicit_backend_log_file = backend_config.get("log_file")
+        if explicit_backend_log_file:
+            return explicit_backend_log_file
+        explicit_log_file = log_config.get("log_file")
+        if explicit_log_file:
+            return explicit_log_file
+        results_dir = self.resolve_results_dir(config)
+        return os.path.join(results_dir, experiment_name, f"{experiment_name}_run.log")
+
+    def prepare_environment(self, config: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        """Return environment variable overrides for the backend."""
+        env_overrides: Dict[str, str] = {}
+        if self.name == "local":
+            env_overrides["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
+        if not isinstance(config, dict):
+            return env_overrides
+
+        backend_config = config.get("backend", {}).get(self.name, {})
+        env_overrides.update(backend_config.get("env", {}))
+        return env_overrides
+
+
+class SlurmBackend(ExecutionBackend):
+    def __init__(self) -> None:
+        super().__init__(name="slurm")
+
+
+class LocalBackend(ExecutionBackend):
+    def __init__(self) -> None:
+        super().__init__(name="local")
+
+
+def get_execution_backend(config: Dict[str, Any]) -> ExecutionBackend:
+    """Construct the backend policy from the merged configuration."""
+    general_config = config.get("general", {}) if isinstance(config, dict) else {}
+    backend_name = _normalize_backend_name(general_config.get("backend"))
+    if backend_name == "local":
+        return LocalBackend()
+    return SlurmBackend()

--- a/tests/test_backend_policy.py
+++ b/tests/test_backend_policy.py
@@ -1,0 +1,231 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.utils import backend_policy
+
+
+class FakeTorch:
+    def __init__(self, cuda_available: bool, mps_available: bool, mps_built: bool) -> None:
+        self.cuda = SimpleNamespace(is_available=lambda: cuda_available)
+        self.backends = SimpleNamespace(
+            mps=SimpleNamespace(
+                is_available=lambda: mps_available,
+                is_built=lambda: mps_built,
+            )
+        )
+
+    @staticmethod
+    def device(name: str) -> SimpleNamespace:
+        return SimpleNamespace(type=name)
+
+
+class BackendPolicyTests(unittest.TestCase):
+    def test_local_backend_prefers_mps_for_auto(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=True, mps_built=True),
+        ):
+            device = backend.resolve_device("auto")
+
+        self.assertEqual(device.type, "mps")
+
+    def test_local_backend_uses_cpu_when_mps_unavailable(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            device = backend.resolve_device("auto")
+
+        self.assertEqual(device.type, "cpu")
+
+    def test_local_backend_enables_mps_fallback_env(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        overrides = backend.prepare_environment()
+        self.assertEqual(overrides.get("PYTORCH_ENABLE_MPS_FALLBACK"), "1")
+
+    def test_local_backend_dataloader_defaults(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        defaults = backend.resolve_dataloader_defaults()
+        self.assertEqual(defaults["num_workers"], 0)
+        self.assertFalse(defaults["pin_memory"])
+
+    def test_slurm_backend_defaults_to_slurm(self) -> None:
+        config = {"general": {}}
+        backend = backend_policy.get_execution_backend(config)
+        self.assertEqual(backend.name, "slurm")
+
+    def test_slurm_backend_fallback_device_no_cuda(self) -> None:
+        config = {"general": {"backend": "slurm"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            device = backend.resolve_device("auto")
+
+        self.assertEqual(device.type, "cpu")
+
+    def test_slurm_backend_dataloader_defaults_without_cuda(self) -> None:
+        config = {"general": {"backend": "slurm"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            defaults = backend.resolve_dataloader_defaults()
+
+        self.assertEqual(defaults["num_workers"], 0)
+        self.assertFalse(defaults["pin_memory"])
+
+    def test_dataloader_defaults_honors_legacy_config(self) -> None:
+        config = {
+            "general": {"backend": "local"},
+            "data_loader": {"num_workers": 2, "pin_memory": False},
+        }
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            defaults = backend.resolve_dataloader_defaults(config)
+
+        self.assertEqual(defaults["num_workers"], 2)
+        self.assertFalse(defaults["pin_memory"])
+
+    def test_dataloader_defaults_honors_backend_config(self) -> None:
+        config = {
+            "general": {"backend": "local"},
+            "backend": {
+                "local": {
+                    "data_loader": {"num_workers": 1, "pin_memory": False}
+                }
+            },
+        }
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            defaults = backend.resolve_dataloader_defaults(config)
+
+        self.assertEqual(defaults["num_workers"], 1)
+        self.assertFalse(defaults["pin_memory"])
+
+    def test_backend_config_takes_precedence_over_legacy(self) -> None:
+        config = {
+            "general": {"backend": "local"},
+            "data_loader": {"num_workers": 4, "pin_memory": True},
+            "backend": {
+                "local": {
+                    "data_loader": {"num_workers": 0, "pin_memory": False}
+                }
+            },
+        }
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            defaults = backend.resolve_dataloader_defaults(config)
+
+        self.assertEqual(defaults["num_workers"], 0)
+        self.assertFalse(defaults["pin_memory"])
+
+    def test_resolve_results_dir_local(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+        self.assertEqual(backend.resolve_results_dir(config), "results/local")
+
+    def test_resolve_results_dir_slurm(self) -> None:
+        config = {"general": {"backend": "slurm"}}
+        backend = backend_policy.get_execution_backend(config)
+        self.assertEqual(backend.resolve_results_dir(config), "results")
+
+    def test_resolve_results_dir_from_config(self) -> None:
+        config = {
+            "general": {"backend": "local"},
+            "backend": {"local": {"results_dir": "custom_results"}},
+        }
+        backend = backend_policy.get_execution_backend(config)
+        self.assertEqual(backend.resolve_results_dir(config), "custom_results")
+
+    def test_resolve_log_file_default(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+        log_file = backend.resolve_log_file(config, "test_exp")
+        self.assertIn("results/local/test_exp/test_exp_run.log", log_file)
+
+    def test_slurm_backend_prefers_cuda(self) -> None:
+        config = {"general": {"backend": "slurm"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=True, mps_available=False, mps_built=False),
+        ):
+            device = backend.resolve_device("auto")
+
+        self.assertEqual(device.type, "cuda")
+
+    def test_explicit_cpu_preference(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=True, mps_available=True, mps_built=True),
+        ):
+            device = backend.resolve_device("cpu")
+
+        self.assertEqual(device.type, "cpu")
+
+    def test_explicit_cuda_fallback_to_cpu(self) -> None:
+        config = {"general": {"backend": "local"}}
+        backend = backend_policy.get_execution_backend(config)
+
+        with patch.object(
+            backend_policy,
+            "torch",
+            FakeTorch(cuda_available=False, mps_available=False, mps_built=False),
+        ):
+            device = backend.resolve_device("cuda")
+
+        self.assertEqual(device.type, "cpu")
+
+    def test_get_execution_backend_unknown_name_defaults_slurm(self) -> None:
+        config = {"general": {"backend": "nonexistent"}}
+        backend = backend_policy.get_execution_backend(config)
+        self.assertEqual(backend.name, "slurm")
+
+    def test_get_execution_backend_no_config(self) -> None:
+        backend = backend_policy.get_execution_backend({})
+        self.assertEqual(backend.name, "slurm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `local` execution backend so experiments can run on macOS/Apple Silicon (MPS/CPU) without depending on the Athena Slurm cluster. The existing `slurm` backend remains the default for full backward compatibility.

## Changes

- **Backend policy** (`src/utils/backend_policy.py`) — centralised device resolution (MPS → CUDA → CPU), DataLoader defaults, output/log paths, and environment preparation for `slurm` and `local` backends.
- **CLI** — `run_experiment.py` and `run_optuna_search.py` accept:
  ```bash
  --backend {slurm|local}
  ```
  Config-level default is `"slurm"`.
- **DataLoader defaults** — backend-aware:
  - `local`: `num_workers=0`, `pin_memory=False`
  - `slurm`: `num_workers=4`, `pin_memory=True` when CUDA is available
- **Engine & Optuna objectives** — device selection, environment setup, and loader creation route through the backend policy instead of hard-coded CUDA.
- **Local batch runner** (`scripts/run_local_array.py`) — sequential equivalent of the Slurm array workflow via `--config-dir` or `--glob`.
- **Configuration** — `configs/base.yaml` extended with `general.backend` and `backend.slurm`/`backend.local` sections for backend-specific overrides.
- **Auto-loaded `.env`** — `python-dotenv` loads `WANDB_API_KEY` and `WANDB_ENTITY` at every entry point.
- **Tests** — 19 unit tests covering device fallback, config merging, results directory resolution, and legacy/backend config precedence.
- **Docs** — README updated with Apple Silicon setup, `--backend` usage, and local batch runner examples.

## Backward compatibility

- Default backend is `"slurm"` — existing usage is unaffected.
- Slurm shell scripts (`scripts/slurm_scripts/`) are untouched.
- Existing experiment configs merge correctly with the new `base.yaml` sections.

## Verification

- E2E experiment ran on an M5 Pro MacBook:
  - MF results reached using MPS.
  - CodeCarbon, logging, and graceful CUDA all confirmed.
- All 19 unit tests pass without PyTorch installed (using a `FakeTorch` shim).